### PR TITLE
Skip over non-RLM directories like notify dir

### DIFF
--- a/summary/generate.go
+++ b/summary/generate.go
@@ -20,7 +20,8 @@ type LogDetails struct {
 var rlmsWithLogs []LogDetails
 
 func init() {
-	logFileNames = regexp.MustCompile("[0-9]+_[0-9]+.log")
+	logFileNames = regexp.MustCompile("\d{8}_\d{4}.log")
+	rlmDirNames = regexp.MustCompile("(?:.+\/)?RL\d{5}")
 }
 
 func PrintSummaries() {
@@ -35,6 +36,12 @@ func PrintSummaries() {
 	}
 }
 func SummarizeRLM(rlmdir string) {
+	if !rlmDirNames.MatchString(rlmdir) {
+		if Verbose {
+			fmt.Printf("%s not an RLM directory\n", rlmdir)
+		}
+		return
+	}
 	if Verbose {
 		fmt.Printf("Summarizing %s\n", rlmdir)
 	}


### PR DESCRIPTION
Prevents the program from trying and failing to read dirs such as /home/remotelink/notify/journal which doesn't exist because notify is not an RLM dir. Also tighten regex.